### PR TITLE
indexページのstoreまわりの作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "^4.17.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-redux": "^7.2.6",
     "redux": "^4.1.2",
     "styled-components": "^5.3.1",
     "styled-reset": "^4.3.4"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.6",
     "redux": "^4.1.2",
+    "redux-thunk": "^2.4.1",
     "styled-components": "^5.3.1",
     "styled-reset": "^4.3.4"
   },
@@ -38,6 +39,7 @@
     "eslint-plugin-react": "^7.26.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "prettier": "^2.4.1",
+    "redux-devtools-extension": "^2.13.9",
     "typescript": "^4.4.3",
     "webpack": "^5.53.0",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "^4.17.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "redux": "^4.1.2",
     "styled-components": "^5.3.1",
     "styled-reset": "^4.3.4"
   },

--- a/src/@types/window.d.ts
+++ b/src/@types/window.d.ts
@@ -1,0 +1,7 @@
+import { compose } from "redux";
+
+declare global {
+  interface Window {
+    __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: typeof compose;
+  }
+}

--- a/src/view/index/CSR.tsx
+++ b/src/view/index/CSR.tsx
@@ -1,5 +1,26 @@
 import React from "react";
-import { hydrate } from "react-dom";
+import { render, hydrate } from "react-dom";
+import { Provider } from "react-redux";
+import { applyMiddleware, compose, createStore } from "redux";
+import reduxThunk from "redux-thunk";
 import IndexMainComponent from "./component/IndexMainComponent";
+import reducers from "./stores/index";
 
-hydrate(<IndexMainComponent />, document.getElementById("app"));
+const composeEnhancers =
+  typeof window !== "undefined"
+    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+    : compose;
+const store = createStore(
+  reducers,
+  composeEnhancers(applyMiddleware(reduxThunk))
+);
+
+const root = document.getElementById("app");
+const renderMethod = root && root.innerHTML === "" ? render : hydrate;
+
+renderMethod(
+  <Provider store={store}>
+    <IndexMainComponent />
+  </Provider>,
+  root
+);

--- a/src/view/index/IndexView.tsx
+++ b/src/view/index/IndexView.tsx
@@ -1,8 +1,14 @@
 import React from "react";
+import { Provider } from "react-redux";
 import PageTemplate from "../common/template/PageTemplate";
+import store from "./stores/index";
 
 const IndexView = (): JSX.Element => {
-  return <PageTemplate pageName="index" />;
+  return (
+    <Provider store={store}>
+      <PageTemplate pageName="index" />;
+    </Provider>
+  );
 };
 
 export default IndexView;

--- a/src/view/index/IndexView.tsx
+++ b/src/view/index/IndexView.tsx
@@ -1,14 +1,8 @@
 import React from "react";
-import { Provider } from "react-redux";
 import PageTemplate from "../common/template/PageTemplate";
-import store from "./stores/index";
 
 const IndexView = (): JSX.Element => {
-  return (
-    <Provider store={store}>
-      <PageTemplate pageName="index" />;
-    </Provider>
-  );
+  return <PageTemplate pageName="index" />;
 };
 
 export default IndexView;

--- a/src/view/index/component/IndexFrequentBattledTeams.tsx
+++ b/src/view/index/component/IndexFrequentBattledTeams.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-const MostBattledTeamsWrapper = styled.article`
+const IndexFrequentBattledTeamsWrapper = styled.article`
   width: 300px;
   margin-top: 50px;
   background: #ffffff;
@@ -54,9 +54,9 @@ const MoreLink = styled.a`
   color: #0000ee;
 `;
 
-const IndexMostBattledTeams = (): JSX.Element => {
+const IndexFrequentBattledTeams = (): JSX.Element => {
   return (
-    <MostBattledTeamsWrapper>
+    <IndexFrequentBattledTeamsWrapper>
       <Title>最も対戦しているチーム</Title>
       <TeamList>
         <TeamListItem>
@@ -72,7 +72,7 @@ const IndexMostBattledTeams = (): JSX.Element => {
       <More>
         <MoreLink href="/teams">もっと見る</MoreLink>
       </More>
-    </MostBattledTeamsWrapper>
+    </IndexFrequentBattledTeamsWrapper>
   );
 };
-export default IndexMostBattledTeams;
+export default IndexFrequentBattledTeams;

--- a/src/view/index/component/IndexFrequentBattledTeams.tsx
+++ b/src/view/index/component/IndexFrequentBattledTeams.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
-import { FrequentBattledTeams, IndexState } from "../stores";
+import { IndexState } from "../stores";
 
 const IndexFrequentBattledTeamsWrapper = styled.article`
   width: 300px;

--- a/src/view/index/component/IndexFrequentBattledTeams.tsx
+++ b/src/view/index/component/IndexFrequentBattledTeams.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
+import { FrequentBattledTeams, IndexState } from "../stores";
 
 const IndexFrequentBattledTeamsWrapper = styled.article`
   width: 300px;
@@ -55,19 +57,20 @@ const MoreLink = styled.a`
 `;
 
 const IndexFrequentBattledTeams = (): JSX.Element => {
+  const { teams } = useSelector(
+    (state: IndexState) => state.frequentBattledTeams
+  );
   return (
     <IndexFrequentBattledTeamsWrapper>
       <Title>最も対戦しているチーム</Title>
       <TeamList>
-        <TeamListItem>
-          <TeamListItemLink href="/teams/teamB">チームB</TeamListItemLink>
-        </TeamListItem>
-        <TeamListItem>
-          <TeamListItemLink href="/teams/teamC">チームC</TeamListItemLink>
-        </TeamListItem>
-        <TeamListItem>
-          <TeamListItemLink href="/teams/teamD">チームD</TeamListItemLink>
-        </TeamListItem>
+        {teams.map((team) => (
+          <TeamListItem>
+            <TeamListItemLink href={`teams/${team.teamId}`}>
+              ${team.teamName}
+            </TeamListItemLink>
+          </TeamListItem>
+        ))}
       </TeamList>
       <More>
         <MoreLink href="/teams">もっと見る</MoreLink>

--- a/src/view/index/component/IndexInformation.tsx
+++ b/src/view/index/component/IndexInformation.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import IndexMostBattledTeams from "./IndexMostBattledTeams";
+import IndexFrequentBattledTeams from "./IndexFrequentBattledTeams";
 import IndexLatestGames from "./IndexLatestGames";
 import styled from "styled-components";
 
@@ -18,7 +18,7 @@ const IndexInformation = (): JSX.Element => {
   return (
     <Information>
       <HiddenH1>管理しているチーム情報の概要</HiddenH1>
-      <IndexMostBattledTeams />
+      <IndexFrequentBattledTeams />
       <IndexLatestGames />
     </Information>
   );

--- a/src/view/index/component/IndexLatestGames.tsx
+++ b/src/view/index/component/IndexLatestGames.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
+import { IndexState } from "../stores";
 
 const LatestGamesWrapper = styled.article`
   width: 300px;
@@ -56,26 +58,20 @@ const DetailActionLink = styled.a`
   color: #0000ee;
 `;
 
-const IndexLatestGames = (): JSX.Element => {
+const IndexLatestGames: React.FC = () => {
+  const { scores } = useSelector((state: IndexState) => state.latestGameScores);
   return (
     <LatestGamesWrapper>
       <Title>対戦戦績</Title>
       <GameList>
-        <GameListItem>
-          <GameListItemLink href="/games/game1">
-            チームA 9 - 0 チームB
-          </GameListItemLink>
-        </GameListItem>
-        <GameListItem>
-          <GameListItemLink href="/games/game2">
-            チームA 10 - 3 チームC
-          </GameListItemLink>
-        </GameListItem>
-        <GameListItem>
-          <GameListItemLink href="/games/game3">
-            チームA 4 - 20 チームC
-          </GameListItemLink>
-        </GameListItem>
+        {scores.map((score) => (
+          <GameListItem>
+            <GameListItemLink href={`/games/${score.gameId}`}>
+              ${score.myTeamName} ${score.myTeamScore} - $
+              {score.oponentTeamName} ${score.oponentTeamScore}
+            </GameListItemLink>
+          </GameListItem>
+        ))}
       </GameList>
       <DetailActions>
         <p>

--- a/src/view/index/stores/index.ts
+++ b/src/view/index/stores/index.ts
@@ -1,4 +1,5 @@
-import { combineReducers } from "redux";
+import { createStore } from "redux";
+
 interface IndexState {
   readonly latestGameScores: LatestGameScores;
   readonly frequentBattledTeams: FrequentBattledTeams;
@@ -28,6 +29,6 @@ const initialState: IndexState = {
   },
 };
 
-const indexReducer = (state: IndexState = initialState) => state;
+const reducer = (state: IndexState = initialState) => state;
 
-export default combineReducers({ indexReducer });
+export default createStore(reducer);

--- a/src/view/index/stores/index.ts
+++ b/src/view/index/stores/index.ts
@@ -1,5 +1,3 @@
-import { createStore } from "redux";
-
 export interface IndexState {
   readonly latestGameScores: LatestGameScores;
   readonly frequentBattledTeams: FrequentBattledTeams;
@@ -31,6 +29,4 @@ const initialState: IndexState = {
   },
 };
 
-const reducer = (state: IndexState = initialState) => state;
-
-export default createStore(reducer);
+export default (state: IndexState = initialState) => state;

--- a/src/view/index/stores/index.ts
+++ b/src/view/index/stores/index.ts
@@ -5,12 +5,13 @@ export interface IndexState {
   readonly frequentBattledTeams: FrequentBattledTeams;
 }
 export interface LatestGameScores {
-  readonly scores: ReadonlyArray<Score>;
+  readonly scores: ReadonlyArray<GameScore>;
 }
 export interface FrequentBattledTeams {
   readonly teams: ReadonlyArray<BattledTeam>;
 }
-interface Score {
+interface GameScore {
+  readonly gameId: string;
   readonly myTeamName: string;
   readonly myTeamScore: number;
   readonly oponentTeamName: string;

--- a/src/view/index/stores/index.ts
+++ b/src/view/index/stores/index.ts
@@ -1,0 +1,33 @@
+import { combineReducers } from "redux";
+interface IndexState {
+  readonly latestGameScores: LatestGameScores;
+  readonly frequentBattledTeams: FrequentBattledTeams;
+}
+interface LatestGameScores {
+  readonly scores: ReadonlyArray<Score>;
+}
+interface Score {
+  readonly myTeamName: string;
+  readonly myTeamScore: number;
+  readonly oponentTeamName: string;
+  readonly oponentTeamScore: number;
+}
+interface FrequentBattledTeams {
+  readonly teams: ReadonlyArray<BattledTeam>;
+}
+interface BattledTeam {
+  readonly teamName: string;
+}
+
+const initialState: IndexState = {
+  latestGameScores: {
+    scores: [],
+  },
+  frequentBattledTeams: {
+    teams: [],
+  },
+};
+
+const indexReducer = (state: IndexState = initialState) => state;
+
+export default combineReducers({ indexReducer });

--- a/src/view/index/stores/index.ts
+++ b/src/view/index/stores/index.ts
@@ -1,11 +1,14 @@
 import { createStore } from "redux";
 
-interface IndexState {
+export interface IndexState {
   readonly latestGameScores: LatestGameScores;
   readonly frequentBattledTeams: FrequentBattledTeams;
 }
-interface LatestGameScores {
+export interface LatestGameScores {
   readonly scores: ReadonlyArray<Score>;
+}
+export interface FrequentBattledTeams {
+  readonly teams: ReadonlyArray<BattledTeam>;
 }
 interface Score {
   readonly myTeamName: string;
@@ -13,10 +16,8 @@ interface Score {
   readonly oponentTeamName: string;
   readonly oponentTeamScore: number;
 }
-interface FrequentBattledTeams {
-  readonly teams: ReadonlyArray<BattledTeam>;
-}
 interface BattledTeam {
+  readonly teamId: string;
   readonly teamName: string;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,7 +937,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.9.2":
+"@babel/runtime@^7.15.4", "@babel/runtime@^7.9.2":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
   integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
@@ -1113,6 +1113,14 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/json-schema@*", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -1154,6 +1162,16 @@
   integrity sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==
   dependencies:
     "@types/react" "*"
+
+"@types/react-redux@^7.1.20":
+  version "7.1.21"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.21.tgz#f32bbaf7cbc4b93f51e10d340aa54035c084b186"
+  integrity sha512-bLdglUiBSQNzWVVbmNPKGYYjrzp3/YDPwfOH3nLEz99I4awLlaRAPWjo6bZ2POpxztFWtDDXIPxBLVykXqBt+w==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react@*", "@types/react@^17.0.24":
   version "17.0.24"
@@ -2572,7 +2590,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hoist-non-react-statics@^3.0.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -3454,6 +3472,23 @@ react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-redux@^7.2.6:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
+  integrity sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
+
 react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
@@ -3493,7 +3528,7 @@ rechoir@^0.7.0:
   dependencies:
     resolve "^1.9.0"
 
-redux@^4.1.2:
+redux@^4.0.0, redux@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
   integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,6 +937,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.9.2":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
+  integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
@@ -3485,6 +3492,13 @@ rechoir@^0.7.0:
   integrity sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==
   dependencies:
     resolve "^1.9.0"
+
+redux@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
+  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 regenerate-unicode-properties@^9.0.0:
   version "9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3528,6 +3528,16 @@ rechoir@^0.7.0:
   dependencies:
     resolve "^1.9.0"
 
+redux-devtools-extension@^2.13.9:
+  version "2.13.9"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz#6b764e8028b507adcb75a1cae790f71e6be08ae7"
+  integrity sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==
+
+redux-thunk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
+  integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
+
 redux@^4.0.0, redux@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"


### PR DESCRIPTION
### 概要
indexページのstoreまわりとかの作成
### やったこと
- reduxのimport
- stateの作成
- コンポーネントの変数が入る場所に変数を代入（ログイン名以外）
- windowの型定義追加
- redux dev-toolの設定追加
### 確認事項
- redux devtoolでstateの初期値が入っていること
- 表示ができること